### PR TITLE
fix: adding forwarding unhandled __call/__callStatic to EnumCollection parent

### DIFF
--- a/src/EnumCollection.php
+++ b/src/EnumCollection.php
@@ -84,6 +84,8 @@ class EnumCollection extends Collection
         if ($method === 'tryFrom') {
             return EnumCollection::of($enumClass)->tryFrom($data);
         }
+
+        return parent::__callStatic($method, $parameters);
     }
 
     public function __call($method, $parameters)
@@ -113,6 +115,8 @@ class EnumCollection extends Collection
 
             return $this;
         }
+
+        return parent::__call($method, $parameters);
     }
 
     /**

--- a/tests/EnumCollectionTest.php
+++ b/tests/EnumCollectionTest.php
@@ -147,3 +147,20 @@ it('will can check if EnumCollection contains enum', function ($from, $search, $
     'string enum collection search name' => [[StringBackedEnum::LARGE, StringBackedEnum::EXTRA_LARGE], 'EXTRA_LARGE', true],
     'string enum collection search invalid name' => [[StringBackedEnum::LARGE, StringBackedEnum::EXTRA_LARGE], 'SMALL', false],
 ]);
+
+it('forwards call to underlying collection', function () {
+    $collection = EnumCollection::from([PureEnum::GREEN, PureEnum::BLACK]);
+    expect($collection->count())->toEqual(2);
+    expect($collection->contains('GREEN'))->toEqual(true);
+    expect($collection->contains('PURPLE'))->toEqual(false);
+});
+
+it('throws on call to non existent method', function () {
+    $collection = EnumCollection::from([PureEnum::GREEN, PureEnum::BLACK]);
+    $collection->foo();
+})->throws(BadMethodCallException::class);
+
+it('throws on call to non existent static method', function () {
+    $collection = EnumCollection::from([PureEnum::GREEN, PureEnum::BLACK]);
+    $collection::foo();
+})->throws(BadMethodCallException::class);


### PR DESCRIPTION
Currently, whenever you call a method that is not defined neither in the EnumCollection nor in its parent/traits/etc, it returns null without throwing an exception (I noticed that thanks to a typo)
```php
EnumCollection::from([])->randomMethod() // returns null
```